### PR TITLE
Removing local cluster from graphcool.yml

### DIFF
--- a/examples/1.0/auth/database/graphcool.yml
+++ b/examples/1.0/auth/database/graphcool.yml
@@ -9,5 +9,3 @@ datamodel: datamodel.graphql
 # to disable authentication:
 # disableAuth: true
 secret: mysecret123
-
-cluster: local

--- a/examples/1.0/file-api/database/graphcool.yml
+++ b/examples/1.0/file-api/database/graphcool.yml
@@ -6,4 +6,3 @@ cluster: local
 datamodel:
   - datamodel.graphql
   
-secret: ${env:GRAPHCOOL_SECRET}

--- a/examples/1.0/file-api/database/graphcool.yml
+++ b/examples/1.0/file-api/database/graphcool.yml
@@ -1,7 +1,8 @@
 service: graphql-server-file-upload-example
 
 stage: dev
-cluster: local
+
+secret: ${env:GRAPHCOOL_SECRET}
 
 datamodel:
   - datamodel.graphql

--- a/examples/1.0/github-auth/graphcool.yml
+++ b/examples/1.0/github-auth/graphcool.yml
@@ -1,7 +1,6 @@
 service: graphql-server-github-auth-example
 
 stage: dev
-cluster: local
 
 datamodel:
   - database/datamodel/types.graphql

--- a/examples/1.0/permissions/README.md
+++ b/examples/1.0/permissions/README.md
@@ -40,8 +40,8 @@ You need to have the following things installed:
 Clone the Graphcool monorepo and navigate to this directory or download _only_ this example with the following command:
 
 ```sh
-curl https://codeload.github.com/graphcool/graphcool/tar.gz/master | tar -xz --strip=2 graphcool-master/examples/permissions
-cd permissions
+curl https://codeload.github.com/graphcool/graphcool/tar.gz/master | tar -xz --strip=2 graphcool-master/examples/1.0/permissions
+cd 1.0/permissions
 ```
 
 ### 2. Deploy the Graphcool database service

--- a/examples/1.0/permissions/database/graphcool.yml
+++ b/examples/1.0/permissions/database/graphcool.yml
@@ -6,4 +6,3 @@ datamodel: datamodel.graphql
 
 secret: ${env:GRAPHCOOL_SECRET}
 
-cluster: local

--- a/examples/1.0/rest-wrapper/database/graphcool.yml
+++ b/examples/1.0/rest-wrapper/database/graphcool.yml
@@ -5,5 +5,3 @@ stage: ${env:GRAPHCOOL_STAGE}
 datamodel: datamodel.graphql
 
 secret: ${env:GRAPHCOOL_SECRET}
-
-cluster: local

--- a/examples/1.0/subscriptions/database/graphcool.yml
+++ b/examples/1.0/subscriptions/database/graphcool.yml
@@ -3,7 +3,6 @@ service: subscriptions
 
 # the cluster and stage the service is deployed to
 stage: dev
-cluster: local
 
 # to disable authentication:
 # disableAuth: true


### PR DESCRIPTION
- Remove local cluster option from 1.0 examples, to allow choosing a cluster on deployment.

- update download link in permissions example